### PR TITLE
Add github action to run and report the mutation test

### DIFF
--- a/.github/workflows/mutation-summary.yml
+++ b/.github/workflows/mutation-summary.yml
@@ -29,10 +29,5 @@ jobs:
 
       - name: Parse PITest XML and Generate Summary
         id: parse_summary
-        run: echo "::set-output name=summary::$(node .github/workflows/parse-pitest-summary.js)"
         shell: bash
-
-
-      - name: Upload mutation test summary
-        run: echo "${{ steps.parse_summary.outputs.summary }}" >> $GITHUB_STEP_SUMMARY
-
+        run: echo $(node .github/workflows/parse-pitest-summary.js) >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/mutation-summary.yml
+++ b/.github/workflows/mutation-summary.yml
@@ -1,6 +1,6 @@
 name: Mutation Test Summary
 
-on: [ pull_request ]
+on: [ workflow_dispatch ]
 
 jobs:
   mutation-summary:

--- a/.github/workflows/mutation-summary.yml
+++ b/.github/workflows/mutation-summary.yml
@@ -28,6 +28,6 @@ jobs:
         run: npm install xml2js
 
       - name: Parse PITest XML and Generate Summary
-        run: node parse-pitest-summary.js
+        run: node .github/workflows/parse-pitest-summary.js
         env:
           GITHUB_STEP_SUMMARY: ${{ github.step_summary }}

--- a/.github/workflows/mutation-summary.yml
+++ b/.github/workflows/mutation-summary.yml
@@ -25,9 +25,8 @@ jobs:
         uses: actions/setup-node@v4
 
       - name: Install dependencies
-        run: npm install xml2js
+        run: npm install @actions/core xml2js
 
       - name: Parse PITest XML and Generate Summary
         run: node .github/workflows/parse-pitest-summary.js
-        env:
-          GITHUB_STEP_SUMMARY: ${{ github.step_summary }}
+

--- a/.github/workflows/mutation-summary.yml
+++ b/.github/workflows/mutation-summary.yml
@@ -28,6 +28,6 @@ jobs:
         run: npm install xml2js
 
       - name: Parse PITest XML and Generate Summary
-        id: parse_summary
-        shell: bash
-        run: echo $(node .github/workflows/parse-pitest-summary.js) >> $GITHUB_STEP_SUMMARY
+        run: node parse-pitest-summary.js
+        env:
+          GITHUB_STEP_SUMMARY: ${{ github.step_summary }}

--- a/.github/workflows/mutation-summary.yml
+++ b/.github/workflows/mutation-summary.yml
@@ -1,6 +1,6 @@
 name: Mutation Test Summary
 
-on: [ push, pull_request ]
+on: [ pull_request ]
 
 jobs:
   mutation-summary:
@@ -29,7 +29,7 @@ jobs:
 
       - name: Parse PITest XML and Generate Summary
         id: parse_summary
-        run: echo "::set-output name=summary::$(node parse-pitest-summary.js)"
+        run: echo "::set-output name=summary::$(node .github/workflows/parse-pitest-summary.js)"
         shell: bash
 
 

--- a/.github/workflows/mutation-summary.yml
+++ b/.github/workflows/mutation-summary.yml
@@ -1,0 +1,38 @@
+name: Mutation Test Summary
+
+on: [ push, pull_request ]
+
+jobs:
+  mutation-summary:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: 'temurin'
+          # Instead of manually configure caching of gradle, use an action which
+          # is provided. Details here: https://github.com/actions/setup-java
+          cache: gradle
+
+      - name: Run mutation tests
+        run: ./gradlew pitest
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+
+      - name: Install dependencies
+        run: npm install xml2js
+
+      - name: Parse PITest XML and Generate Summary
+        id: parse_summary
+        run: echo "::set-output name=summary::$(node parse-pitest-summary.js)"
+        shell: bash
+
+
+      - name: Upload mutation test summary
+        run: echo "${{ steps.parse_summary.outputs.summary }}" >> >> $GITHUB_STEP_SUMMARY
+

--- a/.github/workflows/mutation-summary.yml
+++ b/.github/workflows/mutation-summary.yml
@@ -34,5 +34,5 @@ jobs:
 
 
       - name: Upload mutation test summary
-        run: echo "${{ steps.parse_summary.outputs.summary }}" >> >> $GITHUB_STEP_SUMMARY
+        run: echo "${{ steps.parse_summary.outputs.summary }}" >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/parse-pitest-summary.js
+++ b/.github/workflows/parse-pitest-summary.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const xml2js = require('xml2js');
+
+const parser = new xml2js.Parser();
+fs.readFile('build/reports/pitest/mutations.xml', (err, data) => { // TODO: pass file path as argument
+    if (err) {
+        console.error('Error reading XML file:', err);
+        process.exit(1);
+    }
+
+    parser.parseString(data, (err, result) => {
+        if (err) {
+            console.error('Error parsing XML:', err);
+            process.exit(1);
+        }
+
+        const mutations = result.mutations.mutation;
+        const summaryLines = mutations.map(mutation => {
+            const file = mutation.sourceFile[0];
+            const method = mutation.mutatedMethod[0];
+            const lineNumber = mutation.lineNumber[0];
+            const detected = mutation.$.detected === 'true' ? '✅ Detected' : '❌ Not Detected';
+            const status = mutation.$.status === 'KILLED' ? '💀 Killed' : '🚶 Survived';
+            const description = mutation.description[0];
+
+            return `### Mutation in ${file} (Line: ${lineNumber})
+- **Method**: \`${method}\`
+- **Status**: ${status}
+- **Detection**: ${detected}
+- **Description**: ${description}`;
+        });
+
+        const reportContent = `# Mutation Test Summary
+## Overview
+This report provides an overview of mutation testing results, indicating how mutations were handled by the test suite. Each entry details a mutation attempt, its detection status, and the specific mutation description.
+
+${summaryLines.join('\n')}`;
+
+        console.log(reportContent); // Output to stdout to capture in GitHub Actions
+    });
+});

--- a/.github/workflows/parse-pitest-summary.js
+++ b/.github/workflows/parse-pitest-summary.js
@@ -3,7 +3,7 @@ const xml2js = require('xml2js');
 const core = require('@actions/core');
 
 const parser = new xml2js.Parser();
-fs.readFile('pitest-report.xml', (err, data) => {
+fs.readFile('build/reports/pitest/mutations.xml', (err, data) => {
     if (err) {
         core.setFailed('Error reading XML file: ' + err.message);
         return;

--- a/.github/workflows/parse-pitest-summary.js
+++ b/.github/workflows/parse-pitest-summary.js
@@ -1,17 +1,17 @@
 const fs = require('fs');
 const xml2js = require('xml2js');
-const summaryPath = process.env.GITHUB_STEP_SUMMARY; // Access the GitHub environment variable
+const core = require('@actions/core');
 
 const parser = new xml2js.Parser();
 fs.readFile('pitest-report.xml', (err, data) => {
     if (err) {
-        console.error('Error reading XML file:', err);
+        core.setFailed('Error reading XML file: ' + err.message);
         return;
     }
 
     parser.parseString(data, (err, result) => {
         if (err) {
-            console.error('Error parsing XML:', err);
+            core.setFailed('Error parsing XML: ' + err.message);
             return;
         }
 
@@ -24,20 +24,12 @@ fs.readFile('pitest-report.xml', (err, data) => {
             const status = mutation.$.status === 'KILLED' ? '💀 Killed' : '🚶 Survived';
             const description = mutation.description[0];
 
-            return `### Mutation in ${file} (Line: ${lineNumber})
-- **Method**: \`${method}\`
-- **Status**: ${status}
-- **Detection**: ${detected}
-- **Description**: ${description}`;
+            return `### Mutation in ${file} (Line: ${lineNumber})\n- **Method**: \`${method}\`\n- **Status**: ${status}\n- **Detection**: ${detected}\n- **Description**: ${description}`;
         });
 
-        const reportContent = `# Mutation Test Summary
-## Overview
-This report provides an overview of mutation testing results, indicating how mutations were handled by the test suite. Each entry details a mutation attempt, its detection status, and the specific mutation description.
+        const reportContent = `# Mutation Test Summary\n## Overview\nThis report provides an overview of mutation testing results, indicating how mutations were handled by the test suite. Each entry details a mutation attempt, its detection status, and the specific mutation description.\n\n${summaryLines.join('\n\n')}`;
 
-${summaryLines.join('\n')}`;
-
-        // Write directly to the GitHub Step Summary file
-        fs.appendFileSync(summaryPath, reportContent + '\n');
+        // Write directly to the GitHub Step Summary using @actions/core
+        core.summary.addRaw(reportContent).write();
     });
 });

--- a/.github/workflows/parse-pitest-summary.js
+++ b/.github/workflows/parse-pitest-summary.js
@@ -31,7 +31,13 @@ fs.readFile(filePath, (err, data) => {
             return acc;
         }, {});
 
-        let reportContent = "# Mutation Test Summary\n## Overview\nThis report provides an overview of mutation testing results, grouped by file. Each entry details a mutation attempt, its detection status, and specific mutation description.\n\n";
+        let reportContent = `# Mutation Test Summary
+        
+## Overview
+
+This report provides an overview of mutation testing results, grouped by file. Each entry details a mutation attempt, its detection status, and specific mutation description.
+
+`;
 
         Object.entries(fileGroups).forEach(([file, mutations]) => {
             reportContent += `### Mutations in ${file}\n`;

--- a/.github/workflows/parse-pitest-summary.js
+++ b/.github/workflows/parse-pitest-summary.js
@@ -1,17 +1,18 @@
 const fs = require('fs');
 const xml2js = require('xml2js');
+const summaryPath = process.env.GITHUB_STEP_SUMMARY; // Access the GitHub environment variable
 
 const parser = new xml2js.Parser();
-fs.readFile('build/reports/pitest/mutations.xml', (err, data) => { // TODO: pass file path as argument
+fs.readFile('pitest-report.xml', (err, data) => {
     if (err) {
         console.error('Error reading XML file:', err);
-        process.exit(1);
+        return;
     }
 
     parser.parseString(data, (err, result) => {
         if (err) {
             console.error('Error parsing XML:', err);
-            process.exit(1);
+            return;
         }
 
         const mutations = result.mutations.mutation;
@@ -36,6 +37,7 @@ This report provides an overview of mutation testing results, indicating how mut
 
 ${summaryLines.join('\n')}`;
 
-        console.log(reportContent); // Output to stdout to capture in GitHub Actions
+        // Write directly to the GitHub Step Summary file
+        fs.appendFileSync(summaryPath, reportContent + '\n');
     });
 });


### PR DESCRIPTION
This commit adds a new CI pipeline that can be triggered manually to execute the mutation tests on the repository and write the results to the job's summary.

<img width="1410" alt="image" src="https://github.com/yonatankarp/mutation-testing/assets/14914865/f975c196-d52c-41f6-b741-68b1be9b4cbe">
